### PR TITLE
Use fhiclcpp in favor of fhiclcppsimple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 include(CPM)
 
 find_package(ROOT 6.10 REQUIRED)
+find_package(fhiclcpp 4.17 REQUIRED)
 
 CPMFindPackage(
     NAME systematicstools
@@ -51,7 +52,7 @@ endif()
 ###### Compiler set up
 add_library(nusystematics_dependencies INTERFACE)
 target_link_libraries(nusystematics_dependencies INTERFACE 
-  fhiclcppsimple::includes)
+  fhiclcpp::fhiclcpp)
 target_include_directories(nusystematics_dependencies INTERFACE 
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:include> )

--- a/src/nusystematics/interface/IGENIESystProvider_tool.hh
+++ b/src/nusystematics/interface/IGENIESystProvider_tool.hh
@@ -2,7 +2,7 @@
 
 #include "systematicstools/interface/ISystProviderTool.hh"
 
-#include "fhiclcppsimple/ParameterSet.h"
+#include "fhiclcpp/ParameterSet.h"
 
 // GENIE
 #include "Framework/EventGen/EventRecord.h"
@@ -68,7 +68,7 @@ protected:
   }
 
 public:
-  IGENIESystProvider_tool(fhiclsimple::ParameterSet const &ps)
+  IGENIESystProvider_tool(fhicl::ParameterSet const &ps)
       : ISystProviderTool(ps), fGENIEModuleLabel(ps.get<std::string>(
                                    "genie_module_label", "generator")) {
 

--- a/src/nusystematics/responsecalculators/EnuBinnedTemplateResponseCalculator.hh
+++ b/src/nusystematics/responsecalculators/EnuBinnedTemplateResponseCalculator.hh
@@ -64,7 +64,7 @@ private:
   ///    ] # optional if all of input_file_pattern, input_hist_pattern,
   ///      # e_uniform, and param_values are specified
   /// }
-  void LoadInputHistograms(fhiclsimple::ParameterSet const &ps) {
+  void LoadInputHistograms(fhicl::ParameterSet const &ps) {
     bool uniform_enu = false;
     bool consistent_param_values = false;
 
@@ -98,7 +98,7 @@ private:
       if (!consistent_param_values || !uniform_enu) {
         throw;
       }
-      std::vector<fhiclsimple::ParameterSet> value_descriptors;
+      std::vector<fhicl::ParameterSet> value_descriptors;
       for (size_t e_stop_ctr = 0; e_stop_ctr < (EnuBinning.size() - 1);
            ++e_stop_ctr) {
         std::pair<double, double> enu_range =
@@ -118,13 +118,13 @@ private:
               input_hist_pattern_stop, "%V",
               StringifyNumberToOneDP(param_values[pval_ctr]));
 
-          fhiclsimple::ParameterSet value_descriptor;
+          fhicl::ParameterSet value_descriptor;
           value_descriptor.put("value", param_values[pval_ctr]);
           value_descriptor.put("input_file", input_file);
           value_descriptor.put("input_hist", input_hist);
           value_descriptors.push_back(std::move(value_descriptor));
         }
-        fhiclsimple::ParameterSet estop_descriptor;
+        fhicl::ParameterSet estop_descriptor;
         estop_descriptor.put("inputs", value_descriptors);
         EnuResponses.emplace_back();
         EnuResponses.back().LoadInputHistograms(estop_descriptor);
@@ -133,10 +133,10 @@ private:
     }
 
     size_t e_stop_ctr = 0;
-    for (fhiclsimple::ParameterSet const &e_stop :
-         ps.get<std::vector<fhiclsimple::ParameterSet>>("e_stops")) {
+    for (fhicl::ParameterSet const &e_stop :
+         ps.get<std::vector<fhicl::ParameterSet>>("e_stops")) {
 
-      fhiclsimple::ParameterSet estop_descriptor;
+      fhicl::ParameterSet estop_descriptor;
       std::pair<double, double> enu_range;
 
       if (!e_stop.has_key("enu_range") && uniform_enu) {
@@ -177,10 +177,10 @@ private:
         continue; // next_estop
       }
 
-      std::vector<fhiclsimple::ParameterSet> value_descriptors;
+      std::vector<fhicl::ParameterSet> value_descriptors;
       size_t param_value_it = 0;
-      for (fhiclsimple::ParameterSet const &param_value :
-           e_stop.get<std::vector<fhiclsimple::ParameterSet>>("param_values")) {
+      for (fhicl::ParameterSet const &param_value :
+           e_stop.get<std::vector<fhicl::ParameterSet>>("param_values")) {
         double value;
         if (!param_value.has_key("value") && consistent_param_values) {
           value = param_values[param_value_it];
@@ -198,7 +198,7 @@ private:
             systtools::str_replace(input_hist_pattern_stop, "%V",
                                    StringifyNumberToOneDP(value)));
 
-        fhiclsimple::ParameterSet value_descriptor;
+        fhicl::ParameterSet value_descriptor;
         value_descriptor.put("value", value);
         value_descriptor.put("input_file", input_file);
         value_descriptor.put("input_hist", input_hist);
@@ -227,7 +227,7 @@ private:
   }
 
 public:
-  EnuBinnedTemplateResponseCalculator(fhiclsimple::ParameterSet const &ps) {
+  EnuBinnedTemplateResponseCalculator(fhicl::ParameterSet const &ps) {
     LoadInputHistograms(ps);
   };
 

--- a/src/nusystematics/responsecalculators/MINERvARPAq0q3_ReWeight.hh
+++ b/src/nusystematics/responsecalculators/MINERvARPAq0q3_ReWeight.hh
@@ -27,7 +27,7 @@ class MINERvARPAq0q3_ReWeight
 public:
   enum class RPATweak_t { kCV = 0, kPlus1 = 1, kMinus1 = -1 };
 
-  MINERvARPAq0q3_ReWeight(fhiclsimple::ParameterSet const &InputManifest) {
+  MINERvARPAq0q3_ReWeight(fhicl::ParameterSet const &InputManifest) {
     LoadInputHistograms(InputManifest);
   }
 

--- a/src/nusystematics/responsecalculators/TemplateResponseCalculatorBase.hh
+++ b/src/nusystematics/responsecalculators/TemplateResponseCalculatorBase.hh
@@ -7,7 +7,7 @@
 #include "systematicstools/utility/ROOTUtility.hh"
 #include "systematicstools/utility/exceptions.hh"
 
-#include "fhiclcppsimple/ParameterSet.h"
+#include "fhiclcpp/ParameterSet.h"
 
 #include "TH1.h"
 #include "TH2.h"
@@ -56,7 +56,7 @@ public:
   ///      }
   ///    ]
   ///  }
-  void LoadInputHistograms(fhiclsimple::ParameterSet const &ps);
+  void LoadInputHistograms(fhicl::ParameterSet const &ps);
 
   typedef Int_t bin_it_t;
 
@@ -112,12 +112,12 @@ void TemplateResponseCalculatorBase<
 
 template <size_t NDims, bool Continuous, size_t PolyResponseOrder>
 void TemplateResponseCalculatorBase<NDims, Continuous, PolyResponseOrder>::
-    LoadInputHistograms(fhiclsimple::ParameterSet const &ps) {
+    LoadInputHistograms(fhicl::ParameterSet const &ps) {
 
   std::string const &default_root_file = ps.get<std::string>("input_file", "");
 
-  for (fhiclsimple::ParameterSet const &val_config :
-       ps.get<std::vector<fhiclsimple::ParameterSet>>("inputs")) {
+  for (fhicl::ParameterSet const &val_config :
+       ps.get<std::vector<fhicl::ParameterSet>>("inputs")) {
     double pval = val_config.get<double>("value");
     std::string input_file =
         val_config.get<std::string>("input_file", default_root_file);

--- a/src/nusystematics/systproviders/BeRPAWeight_tool.cc
+++ b/src/nusystematics/systproviders/BeRPAWeight_tool.cc
@@ -16,7 +16,7 @@ using namespace systtools;
 
 // #define BERPAWEIGHT_DEBUG
 
-BeRPAWeight::BeRPAWeight(fhiclsimple::ParameterSet const &params)
+BeRPAWeight::BeRPAWeight(fhicl::ParameterSet const &params)
     : IGENIESystProvider_tool(params),
       pidx_BeRPA_Response(kParamUnhandled<size_t>),
       pidx_BeRPA_A(kParamUnhandled<size_t>),
@@ -25,7 +25,7 @@ BeRPAWeight::BeRPAWeight(fhiclsimple::ParameterSet const &params)
       pidx_BeRPA_E(kParamUnhandled<size_t>), valid_file(nullptr),
       valid_tree(nullptr) {}
 
-SystMetaData BeRPAWeight::BuildSystMetaData(fhiclsimple::ParameterSet const &ps,
+SystMetaData BeRPAWeight::BuildSystMetaData(fhicl::ParameterSet const &ps,
                                             paramId_t firstId) {
 
   SystMetaData smd;
@@ -44,7 +44,7 @@ SystMetaData BeRPAWeight::BuildSystMetaData(fhiclsimple::ParameterSet const &ps,
   for (std::string const &pname :
        {"BeRPA_A", "BeRPA_B", "BeRPA_D", "BeRPA_E"}) {
     SystParamHeader phdr;
-    if (ParseFHiCLSimpleToolConfigurationParameter(ps, pname, phdr, firstId)) {
+    if (ParseFhiclToolConfigurationParameter(ps, pname, phdr, firstId)) {
       phdr.systParamId = firstId++;
       if (!ignore_parameter_dependence) {
         dependentParamNames.push_back(phdr.prettyName);
@@ -81,7 +81,7 @@ SystMetaData BeRPAWeight::BuildSystMetaData(fhiclsimple::ParameterSet const &ps,
 }
 
 bool BeRPAWeight::SetupResponseCalculator(
-    fhiclsimple::ParameterSet const &tool_options) {
+    fhicl::ParameterSet const &tool_options) {
 
   ignore_parameter_dependence =
       tool_options.get<bool>("ignore_parameter_dependence", false);

--- a/src/nusystematics/systproviders/BeRPAWeight_tool.hh
+++ b/src/nusystematics/systproviders/BeRPAWeight_tool.hh
@@ -11,12 +11,12 @@
 class BeRPAWeight : public nusyst::IGENIESystProvider_tool {
 
 public:
-  explicit BeRPAWeight(fhiclsimple::ParameterSet const &);
+  explicit BeRPAWeight(fhicl::ParameterSet const &);
 
-  bool SetupResponseCalculator(fhiclsimple::ParameterSet const &);
-  fhiclsimple::ParameterSet GetExtraToolOptions() { return tool_options; }
+  bool SetupResponseCalculator(fhicl::ParameterSet const &);
+  fhicl::ParameterSet GetExtraToolOptions() { return tool_options; }
 
-  systtools::SystMetaData BuildSystMetaData(fhiclsimple::ParameterSet const &,
+  systtools::SystMetaData BuildSystMetaData(fhicl::ParameterSet const &,
                                             systtools::paramId_t);
 
   systtools::event_unit_response_t GetEventResponse(genie::EventRecord const &);
@@ -26,7 +26,7 @@ public:
   ~BeRPAWeight();
 
 private:
-  fhiclsimple::ParameterSet tool_options;
+  fhicl::ParameterSet tool_options;
 
   bool ApplyCV;
 

--- a/src/nusystematics/systproviders/EbLepMomShift_tool.cc
+++ b/src/nusystematics/systproviders/EbLepMomShift_tool.cc
@@ -8,18 +8,18 @@
 using namespace nusyst;
 using namespace systtools;
 
-EbLepMomShift::EbLepMomShift(fhiclsimple::ParameterSet const &params)
+EbLepMomShift::EbLepMomShift(fhicl::ParameterSet const &params)
     : IGENIESystProvider_tool(params),
       ResponseParameterIdx(systtools::kParamUnhandled<size_t>),
       valid_file(nullptr), valid_tree(nullptr) {}
 
-SystMetaData EbLepMomShift::BuildSystMetaData(fhiclsimple::ParameterSet const &ps,
+SystMetaData EbLepMomShift::BuildSystMetaData(fhicl::ParameterSet const &ps,
                                               paramId_t firstId) {
 
   SystMetaData smd;
 
   SystParamHeader phdr;
-  if (ParseFHiCLSimpleToolConfigurationParameter(ps, "EbFSLepMomShift", phdr,
+  if (ParseFhiclToolConfigurationParameter(ps, "EbFSLepMomShift", phdr,
                                                  firstId)) {
     phdr.systParamId = firstId++;
     phdr.isWeightSystematicVariation = false;
@@ -36,8 +36,8 @@ SystMetaData EbLepMomShift::BuildSystMetaData(fhiclsimple::ParameterSet const &p
            "nusystematics/responsecalculators/"
            "TemplateResponseCalculatorBase.hh for the layout.";
   }
-  fhiclsimple::ParameterSet templateManifest =
-      ps.get<fhiclsimple::ParameterSet>("EbLepMomShift_Template_input_manifest");
+  fhicl::ParameterSet templateManifest =
+      ps.get<fhicl::ParameterSet>("EbLepMomShift_Template_input_manifest");
   tool_options.put("EbLepMomShift_Template_input_manifest", templateManifest);
 
   tool_options.put("fill_valid_tree", ps.get<bool>("fill_valid_tree", false));
@@ -46,7 +46,7 @@ SystMetaData EbLepMomShift::BuildSystMetaData(fhiclsimple::ParameterSet const &p
 }
 
 bool EbLepMomShift::SetupResponseCalculator(
-    fhiclsimple::ParameterSet const &tool_options) {
+    fhicl::ParameterSet const &tool_options) {
 
   SystMetaData const &md = GetSystMetaData();
 
@@ -66,8 +66,8 @@ bool EbLepMomShift::SetupResponseCalculator(
            "please report to the maintiner.";
   }
 
-  fhiclsimple::ParameterSet const &templateManifest =
-      tool_options.get<fhiclsimple::ParameterSet>(
+  fhicl::ParameterSet const &templateManifest =
+      tool_options.get<fhicl::ParameterSet>(
           "EbLepMomShift_Template_input_manifest");
 
   ResponseParameterIdx = GetParamIndex(md, "EbFSLepMomShift");

--- a/src/nusystematics/systproviders/EbLepMomShift_tool.hh
+++ b/src/nusystematics/systproviders/EbLepMomShift_tool.hh
@@ -21,12 +21,12 @@ class EbLepMomShift : public nusyst::IGENIESystProvider_tool {
   };
 
 public:
-  explicit EbLepMomShift(fhiclsimple::ParameterSet const &);
+  explicit EbLepMomShift(fhicl::ParameterSet const &);
 
-  bool SetupResponseCalculator(fhiclsimple::ParameterSet const &);
-  fhiclsimple::ParameterSet GetExtraToolOptions() { return tool_options; }
+  bool SetupResponseCalculator(fhicl::ParameterSet const &);
+  fhicl::ParameterSet GetExtraToolOptions() { return tool_options; }
 
-  systtools::SystMetaData BuildSystMetaData(fhiclsimple::ParameterSet const &,
+  systtools::SystMetaData BuildSystMetaData(fhicl::ParameterSet const &,
                                             systtools::paramId_t);
 
   systtools::event_unit_response_t GetEventResponse(genie::EventRecord const &);
@@ -36,7 +36,7 @@ public:
   ~EbLepMomShift();
 
 private:
-  fhiclsimple::ParameterSet tool_options;
+  fhicl::ParameterSet tool_options;
 
   size_t ResponseParameterIdx;
 

--- a/src/nusystematics/systproviders/FSILikeEAvailSmearing_tool.cc
+++ b/src/nusystematics/systproviders/FSILikeEAvailSmearing_tool.cc
@@ -11,7 +11,7 @@
 
 using namespace systtools;
 using namespace nusyst;
-using namespace fhiclsimple;
+using namespace fhicl;
 
 // #define DEBUG_MKSINGLEPI
 
@@ -25,14 +25,14 @@ SystMetaData FSILikeEAvailSmearing::BuildSystMetaData(ParameterSet const &cfg,
   SystMetaData smd;
 
   systtools::SystParamHeader phdr;
-  if (ParseFHiCLSimpleToolConfigurationParameter(cfg, "FSILikeEAvailSmearing",
+  if (ParseFhiclToolConfigurationParameter(cfg, "FSILikeEAvailSmearing",
                                                  phdr, firstId)) {
     phdr.systParamId = firstId++;
     smd.push_back(phdr);
   }
 
-  fhiclsimple::ParameterSet templateManifest =
-      cfg.get<fhiclsimple::ParameterSet>("FSILikeEAvailSmearing_input_manifest");
+  fhicl::ParameterSet templateManifest =
+      cfg.get<fhicl::ParameterSet>("FSILikeEAvailSmearing_input_manifest");
 
   if (!cfg.has_key("FSILikeEAvailSmearing_input_manifest") ||
       !cfg.is_key_to_table("FSILikeEAvailSmearing_input_manifest")) {
@@ -85,7 +85,7 @@ struct channel_id {
 } // namespace
 
 bool FSILikeEAvailSmearing::SetupResponseCalculator(
-    fhiclsimple::ParameterSet const &tool_options) {
+    fhicl::ParameterSet const &tool_options) {
 
   genie::Messenger::Instance()->SetPrioritiesFromXmlFile(
       "Messenger_whisper.xml");
@@ -108,8 +108,8 @@ bool FSILikeEAvailSmearing::SetupResponseCalculator(
            "please report to the maintiner.";
   }
 
-  fhiclsimple::ParameterSet const &templateManifest =
-      tool_options.get<fhiclsimple::ParameterSet>(
+  fhicl::ParameterSet const &templateManifest =
+      tool_options.get<fhicl::ParameterSet>(
           "FSILikeEAvailSmearing_input_manifest");
 
   ResponseParameterIdx =
@@ -133,7 +133,7 @@ bool FSILikeEAvailSmearing::SetupResponseCalculator(
     TemplateHelper th;
     th.Template = std::make_unique<FSILikeEAvailSmearing_ReWeight>();
     th.Template->LoadInputHistograms(
-        templateManifest.get<fhiclsimple::ParameterSet>(ch.name));
+        templateManifest.get<fhicl::ParameterSet>(ch.name));
     th.ZeroIsValid = th.Template->IsValidVariation(0);
 
     ChannelParameterMapping.emplace(ch.channel, std::move(th));

--- a/src/nusystematics/systproviders/FSILikeEAvailSmearing_tool.hh
+++ b/src/nusystematics/systproviders/FSILikeEAvailSmearing_tool.hh
@@ -39,12 +39,12 @@ private:
   std::pair<double, double> LimitWeights;
 
 public:
-  explicit FSILikeEAvailSmearing(fhiclsimple::ParameterSet const &);
+  explicit FSILikeEAvailSmearing(fhicl::ParameterSet const &);
 
-  bool SetupResponseCalculator(fhiclsimple::ParameterSet const &);
-  fhiclsimple::ParameterSet GetExtraToolOptions() { return tool_options; }
+  bool SetupResponseCalculator(fhicl::ParameterSet const &);
+  fhicl::ParameterSet GetExtraToolOptions() { return tool_options; }
 
-  systtools::SystMetaData BuildSystMetaData(fhiclsimple::ParameterSet const &,
+  systtools::SystMetaData BuildSystMetaData(fhicl::ParameterSet const &,
                                             systtools::paramId_t);
 
   systtools::event_unit_response_t GetEventResponse(genie::EventRecord const &);
@@ -54,5 +54,5 @@ public:
   ~FSILikeEAvailSmearing();
 
 private:
-  fhiclsimple::ParameterSet tool_options;
+  fhicl::ParameterSet tool_options;
 };

--- a/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
@@ -159,7 +159,7 @@ void AddIndependentParameters(SystMetaData const &md,
 
 std::vector<GENIEResponseParameter>
 ConfigureQEWeightEngine(SystMetaData const &QEmd,
-                        fhiclsimple::ParameterSet const &tool_options) {
+                        fhicl::ParameterSet const &tool_options) {
 
   std::vector<GENIEResponseParameter> param_map;
 
@@ -265,7 +265,7 @@ ConfigureQEWeightEngine(SystMetaData const &QEmd,
 
 std::vector<GENIEResponseParameter>
 ConfigureNCELWeightEngine(SystMetaData const &NCELmd,
-                          fhiclsimple::ParameterSet const &tool_options) {
+                          fhicl::ParameterSet const &tool_options) {
 
   std::vector<GENIEResponseParameter> param_map;
 
@@ -281,7 +281,7 @@ ConfigureNCELWeightEngine(SystMetaData const &NCELmd,
 
 std::vector<GENIEResponseParameter>
 ConfigureRESWeightEngine(SystMetaData const &RESmd,
-                         fhiclsimple::ParameterSet const &tool_options) {
+                         fhicl::ParameterSet const &tool_options) {
 
   std::vector<GENIEResponseParameter> param_map;
 
@@ -362,7 +362,7 @@ ConfigureRESWeightEngine(SystMetaData const &RESmd,
 
 std::vector<GENIEResponseParameter>
 ConfigureCOHWeightEngine(SystMetaData const &COHmd,
-                         fhiclsimple::ParameterSet const &tool_options) {
+                         fhicl::ParameterSet const &tool_options) {
 
   std::vector<GENIEResponseParameter> param_map;
 
@@ -378,7 +378,7 @@ ConfigureCOHWeightEngine(SystMetaData const &COHmd,
 
 std::vector<GENIEResponseParameter>
 ConfigureDISWeightEngine(SystMetaData const &DISmd,
-                         fhiclsimple::ParameterSet const &tool_options) {
+                         fhicl::ParameterSet const &tool_options) {
 
   std::vector<GENIEResponseParameter> param_map;
 
@@ -413,7 +413,7 @@ ConfigureDISWeightEngine(SystMetaData const &DISmd,
 
 std::vector<GENIEResponseParameter>
 ConfigureFSIWeightEngine(systtools::SystMetaData const &FSImd,
-                         fhiclsimple::ParameterSet const &tool_options) {
+                         fhicl::ParameterSet const &tool_options) {
   std::vector<GENIEResponseParameter> param_map;
 
   bool UseFullHERG = tool_options.get<bool>("UseFullHERG", false);
@@ -435,7 +435,7 @@ ConfigureFSIWeightEngine(systtools::SystMetaData const &FSImd,
 
 std::vector<GENIEResponseParameter>
 ConfigureOtherWeightEngine(systtools::SystMetaData const &Othermd,
-                           fhiclsimple::ParameterSet const &tool_options) {
+                           fhicl::ParameterSet const &tool_options) {
 
   std::vector<GENIEResponseParameter> param_map;
 

--- a/src/nusystematics/systproviders/GENIEReWeightEngineConfig.hh
+++ b/src/nusystematics/systproviders/GENIEReWeightEngineConfig.hh
@@ -4,7 +4,7 @@
 
 #include "nusystematics/systproviders/GENIEResponseParameterAssociation.hh"
 
-#include "fhiclcppsimple/ParameterSet.h"
+#include "fhiclcpp/ParameterSet.h"
 
 // GENIE
 #include "RwFramework/GReWeight.h"
@@ -16,30 +16,30 @@ namespace nusyst {
 
 std::vector<GENIEResponseParameter>
 ConfigureQEWeightEngine(systtools::SystMetaData const &,
-                        fhiclsimple::ParameterSet const &tool_options);
+                        fhicl::ParameterSet const &tool_options);
 
 std::vector<GENIEResponseParameter>
 ConfigureNCELWeightEngine(systtools::SystMetaData const &,
-                          fhiclsimple::ParameterSet const &tool_options);
+                          fhicl::ParameterSet const &tool_options);
 
 std::vector<GENIEResponseParameter>
 ConfigureRESWeightEngine(systtools::SystMetaData const &,
-                         fhiclsimple::ParameterSet const &tool_options);
+                         fhicl::ParameterSet const &tool_options);
 
 std::vector<GENIEResponseParameter>
 ConfigureCOHWeightEngine(systtools::SystMetaData const &,
-                         fhiclsimple::ParameterSet const &tool_options);
+                         fhicl::ParameterSet const &tool_options);
 
 std::vector<GENIEResponseParameter>
 ConfigureDISWeightEngine(systtools::SystMetaData const &,
-                         fhiclsimple::ParameterSet const &tool_options);
+                         fhicl::ParameterSet const &tool_options);
 
 std::vector<GENIEResponseParameter>
 ConfigureFSIWeightEngine(systtools::SystMetaData const &,
-                         fhiclsimple::ParameterSet const &tool_options);
+                         fhicl::ParameterSet const &tool_options);
 
 std::vector<GENIEResponseParameter>
 ConfigureOtherWeightEngine(systtools::SystMetaData const &,
-                           fhiclsimple::ParameterSet const &tool_options);
+                           fhicl::ParameterSet const &tool_options);
 
 } // namespace nusyst

--- a/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/src/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -19,18 +19,18 @@ using namespace genie::rew;
 namespace nusyst {
 
 SystMetaData
-ConfigureSetOfIndependentParameters(fhiclsimple::ParameterSet const &cfg,
+ConfigureSetOfIndependentParameters(fhicl::ParameterSet const &cfg,
                                     paramId_t firstParamId,
                                     std::vector<genie::rew::GSyst_t> Dials) {
 
   SystMetaData MD;
   for (GSyst_t const &gdial : Dials) {
     std::string const &pname = GSyst::AsString(gdial);
-    if (!FHiCLSimpleToolConfigurationParameterExists(cfg, pname)) {
+    if (!FhiclToolConfigurationParameterExists(cfg, pname)) {
       continue;
     }
     systtools::SystParamHeader param;
-    ParseFHiCLSimpleToolConfigurationParameter(cfg, pname, param, firstParamId);
+    ParseFhiclToolConfigurationParameter(cfg, pname, param, firstParamId);
     param.systParamId = firstParamId++;
     MD.push_back(std::move(param));
   }
@@ -38,8 +38,8 @@ ConfigureSetOfIndependentParameters(fhiclsimple::ParameterSet const &cfg,
 }
 
 SystMetaData ConfigureSetOfDependentShapeableParameters(
-    fhiclsimple::ParameterSet const &cfg, paramId_t firstParamId,
-    fhiclsimple::ParameterSet &tool_options, std::string const &ResponseParameterName,
+    fhicl::ParameterSet const &cfg, paramId_t firstParamId,
+    fhicl::ParameterSet &tool_options, std::string const &ResponseParameterName,
     std::vector<std::pair<genie::rew::GSyst_t, genie::rew::GSyst_t>> Dials,
     bool IsShape) {
 
@@ -57,11 +57,11 @@ SystMetaData ConfigureSetOfDependentShapeableParameters(
   size_t NParams = 0;
   for (std::pair<GSyst_t, GSyst_t> const &gdial : Dials) {
     std::string const &pname = GSyst::AsString(gdial.first);
-    if (!FHiCLSimpleToolConfigurationParameterExists(cfg, pname)) {
+    if (!FhiclToolConfigurationParameterExists(cfg, pname)) {
       continue;
     }
     systtools::SystParamHeader param;
-    ParseFHiCLSimpleToolConfigurationParameter(cfg, pname, param, firstParamId);
+    ParseFhiclToolConfigurationParameter(cfg, pname, param, firstParamId);
     param.systParamId = firstParamId++;
     param.prettyName = GSyst::AsString(IsShape ? gdial.second : gdial.first);
     if (!ignore_parameter_dependence) {
@@ -100,8 +100,8 @@ SystMetaData ConfigureSetOfDependentShapeableParameters(
 }
 
 SystMetaData ConfigureSetOfDependentParameters(
-    fhiclsimple::ParameterSet const &cfg, paramId_t firstParamId,
-    fhiclsimple::ParameterSet &tool_options, std::string const &ResponseParameterName,
+    fhicl::ParameterSet const &cfg, paramId_t firstParamId,
+    fhicl::ParameterSet &tool_options, std::string const &ResponseParameterName,
     std::vector<genie::rew::GSyst_t> Dials) {
 
   SystMetaData MD;
@@ -118,11 +118,11 @@ SystMetaData ConfigureSetOfDependentParameters(
   size_t NParams = 0;
   for (GSyst_t const &gdial : Dials) {
     std::string const &pname = GSyst::AsString(gdial);
-    if (!FHiCLSimpleToolConfigurationParameterExists(cfg, pname)) {
+    if (!FhiclToolConfigurationParameterExists(cfg, pname)) {
       continue;
     }
     systtools::SystParamHeader param;
-    ParseFHiCLSimpleToolConfigurationParameter(cfg, pname, param, firstParamId);
+    ParseFhiclToolConfigurationParameter(cfg, pname, param, firstParamId);
     param.systParamId = firstParamId++;
     if (!ignore_parameter_dependence) {
       param.isResponselessParam = true;
@@ -156,33 +156,33 @@ SystMetaData ConfigureSetOfDependentParameters(
   return MD;
 }
 
-SystMetaData ConfigureQEParameterHeaders(fhiclsimple::ParameterSet const &cfg,
+SystMetaData ConfigureQEParameterHeaders(fhicl::ParameterSet const &cfg,
                                          paramId_t firstParamId,
-                                         fhiclsimple::ParameterSet &tool_options) {
+                                         fhicl::ParameterSet &tool_options) {
   SystMetaData QEmd;
 
   bool MaCCQEIsShapeOnly = cfg.get<bool>("MaCCQEIsShapeOnly", false);
   tool_options.put("MaCCQEIsShapeOnly", MaCCQEIsShapeOnly);
 
   // Axial FFs
-  bool DipoleNormCCQEIsUsed = FHiCLSimpleToolConfigurationParameterExists(
+  bool DipoleNormCCQEIsUsed = FhiclToolConfigurationParameterExists(
       cfg, GSyst::AsString(kXSecTwkDial_NormCCQE));
   bool DipoleIsShapeOnly = MaCCQEIsShapeOnly || DipoleNormCCQEIsUsed;
-  bool DipoleMaCCQEIsUsed = FHiCLSimpleToolConfigurationParameterExists(
+  bool DipoleMaCCQEIsUsed = FhiclToolConfigurationParameterExists(
       cfg, GSyst::AsString(kXSecTwkDial_MaCCQE));
 
   bool IsDipoleReWeight =
       DipoleIsShapeOnly || DipoleNormCCQEIsUsed || DipoleMaCCQEIsUsed;
 
-  bool ZNormIsUsed = FHiCLSimpleToolConfigurationParameterExists(
+  bool ZNormIsUsed = FhiclToolConfigurationParameterExists(
       cfg, GSyst::AsString(kXSecTwkDial_ZNormCCQE));
-  bool ZExpA1IsUsed = FHiCLSimpleToolConfigurationParameterExists(
+  bool ZExpA1IsUsed = FhiclToolConfigurationParameterExists(
       cfg, GSyst::AsString(kXSecTwkDial_ZExpA1CCQE));
-  bool ZExpA2IsUsed = FHiCLSimpleToolConfigurationParameterExists(
+  bool ZExpA2IsUsed = FhiclToolConfigurationParameterExists(
       cfg, GSyst::AsString(kXSecTwkDial_ZExpA2CCQE));
-  bool ZExpA3IsUsed = FHiCLSimpleToolConfigurationParameterExists(
+  bool ZExpA3IsUsed = FhiclToolConfigurationParameterExists(
       cfg, GSyst::AsString(kXSecTwkDial_ZExpA3CCQE));
-  bool ZExpA4IsUsed = FHiCLSimpleToolConfigurationParameterExists(
+  bool ZExpA4IsUsed = FhiclToolConfigurationParameterExists(
       cfg, GSyst::AsString(kXSecTwkDial_ZExpA4CCQE));
 
   bool IsZExpReWeight = ZNormIsUsed || ZExpA1IsUsed || ZExpA2IsUsed ||
@@ -203,14 +203,14 @@ SystMetaData ConfigureQEParameterHeaders(fhiclsimple::ParameterSet const &cfg,
   if (IsDipoleReWeight) {
     if (DipoleNormCCQEIsUsed) {
       systtools::SystParamHeader param;
-      ParseFHiCLSimpleToolConfigurationParameter(
+      ParseFhiclToolConfigurationParameter(
           cfg, GSyst::AsString(kXSecTwkDial_NormCCQE), param, firstParamId);
       param.systParamId = firstParamId++;
       QEmd.push_back(std::move(param));
     }
     if (DipoleMaCCQEIsUsed) {
       systtools::SystParamHeader param;
-      ParseFHiCLSimpleToolConfigurationParameter(
+      ParseFhiclToolConfigurationParameter(
           cfg, GSyst::AsString(kXSecTwkDial_MaCCQE), param, firstParamId);
       param.systParamId = firstParamId++;
       param.prettyName = GSyst::AsString(
@@ -222,7 +222,7 @@ SystMetaData ConfigureQEParameterHeaders(fhiclsimple::ParameterSet const &cfg,
     // output its response via the a meta-parameter.
     if (ZNormIsUsed) {
       systtools::SystParamHeader param;
-      ParseFHiCLSimpleToolConfigurationParameter(
+      ParseFhiclToolConfigurationParameter(
           cfg, GSyst::AsString(kXSecTwkDial_ZNormCCQE), param, firstParamId);
       param.systParamId = firstParamId++;
       QEmd.push_back(std::move(param));
@@ -249,24 +249,24 @@ SystMetaData ConfigureQEParameterHeaders(fhiclsimple::ParameterSet const &cfg,
   return QEmd;
 } // namespace nusyst
 
-SystMetaData ConfigureNCELParameterHeaders(fhiclsimple::ParameterSet const &cfg,
+SystMetaData ConfigureNCELParameterHeaders(fhicl::ParameterSet const &cfg,
                                            paramId_t firstParamId,
-                                           fhiclsimple::ParameterSet &tool_options) {
+                                           fhicl::ParameterSet &tool_options) {
   return ConfigureSetOfDependentParameters(
       cfg, firstParamId, tool_options, "NCELVariationResponse",
       {kXSecTwkDial_MaNCEL, kXSecTwkDial_EtaNCEL});
 }
 
-SystMetaData ConfigureRESParameterHeaders(fhiclsimple::ParameterSet const &cfg,
+SystMetaData ConfigureRESParameterHeaders(fhicl::ParameterSet const &cfg,
                                           paramId_t firstParamId,
-                                          fhiclsimple::ParameterSet &tool_options) {
+                                          fhicl::ParameterSet &tool_options) {
   SystMetaData RESmd;
 
   //************* CCRES
   bool CCRESIsShapeOnly = cfg.get<bool>("CCRESIsShapeOnly", false);
   tool_options.put("CCRESIsShapeOnly", CCRESIsShapeOnly);
 
-  bool NormCCRESIsUsed = FHiCLSimpleToolConfigurationParameterExists(
+  bool NormCCRESIsUsed = FhiclToolConfigurationParameterExists(
       cfg, GSyst::AsString(kXSecTwkDial_NormCCRES));
 
   if (NormCCRESIsUsed && !CCRESIsShapeOnly) {
@@ -277,7 +277,7 @@ SystMetaData ConfigureRESParameterHeaders(fhiclsimple::ParameterSet const &cfg,
 
   if (NormCCRESIsUsed) {
     systtools::SystParamHeader param;
-    ParseFHiCLSimpleToolConfigurationParameter(
+    ParseFhiclToolConfigurationParameter(
         cfg, GSyst::AsString(kXSecTwkDial_NormCCRES), param, firstParamId);
     param.systParamId = firstParamId++;
     RESmd.push_back(std::move(param));
@@ -295,7 +295,7 @@ SystMetaData ConfigureRESParameterHeaders(fhiclsimple::ParameterSet const &cfg,
   bool NCRESIsShapeOnly = cfg.get<bool>("NCRESIsShapeOnly", false);
   tool_options.put("NCRESIsShapeOnly", NCRESIsShapeOnly);
 
-  bool NormNCRESIsUsed = FHiCLSimpleToolConfigurationParameterExists(
+  bool NormNCRESIsUsed = FhiclToolConfigurationParameterExists(
       cfg, GSyst::AsString(kXSecTwkDial_NormNCRES));
 
   if (NormNCRESIsUsed && !NCRESIsShapeOnly) {
@@ -306,7 +306,7 @@ SystMetaData ConfigureRESParameterHeaders(fhiclsimple::ParameterSet const &cfg,
 
   if (NormNCRESIsUsed) {
     systtools::SystParamHeader param;
-    ParseFHiCLSimpleToolConfigurationParameter(
+    ParseFhiclToolConfigurationParameter(
         cfg, GSyst::AsString(kXSecTwkDial_NormNCRES), param, firstParamId);
     param.systParamId = firstParamId++;
     RESmd.push_back(std::move(param));
@@ -338,17 +338,17 @@ SystMetaData ConfigureRESParameterHeaders(fhiclsimple::ParameterSet const &cfg,
   return RESmd;
 }
 
-SystMetaData ConfigureCOHParameterHeaders(fhiclsimple::ParameterSet const &cfg,
+SystMetaData ConfigureCOHParameterHeaders(fhicl::ParameterSet const &cfg,
                                           paramId_t firstParamId,
-                                          fhiclsimple::ParameterSet &tool_options) {
+                                          fhicl::ParameterSet &tool_options) {
   return ConfigureSetOfDependentParameters(
       cfg, firstParamId, tool_options, "COHVariationResponse",
       {kXSecTwkDial_MaCOHpi, kXSecTwkDial_R0COHpi});
 }
 
-SystMetaData ConfigureDISParameterHeaders(fhiclsimple::ParameterSet const &cfg,
+SystMetaData ConfigureDISParameterHeaders(fhicl::ParameterSet const &cfg,
                                           paramId_t firstParamId,
-                                          fhiclsimple::ParameterSet &tool_options) {
+                                          fhicl::ParameterSet &tool_options) {
 
   bool DISBYIsShapeOnly = cfg.get<bool>("DISBYIsShapeOnly", false);
   tool_options.put("DISBYIsShapeOnly", DISBYIsShapeOnly);
@@ -375,9 +375,9 @@ SystMetaData ConfigureDISParameterHeaders(fhiclsimple::ParameterSet const &cfg,
   return DISmd;
 }
 
-SystMetaData ConfigureFSIParameterHeaders(fhiclsimple::ParameterSet const &cfg,
+SystMetaData ConfigureFSIParameterHeaders(fhicl::ParameterSet const &cfg,
                                           paramId_t firstParamId,
-                                          fhiclsimple::ParameterSet &tool_options) {
+                                          fhicl::ParameterSet &tool_options) {
 
   SystMetaData FSImd = ConfigureSetOfDependentParameters(
       cfg, firstParamId, tool_options, "FSI_pi_VariationResponse",
@@ -395,7 +395,7 @@ SystMetaData ConfigureFSIParameterHeaders(fhiclsimple::ParameterSet const &cfg,
   return FSImd;
 }
 
-SystMetaData ConfigureOtherParameterHeaders(fhiclsimple::ParameterSet const &cfg,
+SystMetaData ConfigureOtherParameterHeaders(fhicl::ParameterSet const &cfg,
                                             paramId_t firstParamId) {
   return ConfigureSetOfIndependentParameters(
       cfg, firstParamId,

--- a/src/nusystematics/systproviders/GENIEReWeightParamConfig.hh
+++ b/src/nusystematics/systproviders/GENIEReWeightParamConfig.hh
@@ -2,37 +2,37 @@
 
 #include "systematicstools/interface/SystMetaData.hh"
 
-#include "fhiclcppsimple/ParameterSet.h"
+#include "fhiclcpp/ParameterSet.h"
 
 #include <string>
 
 namespace nusyst {
 
 systtools::SystMetaData
-ConfigureQEParameterHeaders(fhiclsimple::ParameterSet const &, systtools::paramId_t,
-                            fhiclsimple::ParameterSet &tool_options);
+ConfigureQEParameterHeaders(fhicl::ParameterSet const &, systtools::paramId_t,
+                            fhicl::ParameterSet &tool_options);
 
 systtools::SystMetaData
-ConfigureNCELParameterHeaders(fhiclsimple::ParameterSet const &, systtools::paramId_t,
-                              fhiclsimple::ParameterSet &tool_options);
+ConfigureNCELParameterHeaders(fhicl::ParameterSet const &, systtools::paramId_t,
+                              fhicl::ParameterSet &tool_options);
 
 systtools::SystMetaData
-ConfigureRESParameterHeaders(fhiclsimple::ParameterSet const &, systtools::paramId_t,
-                             fhiclsimple::ParameterSet &tool_options);
+ConfigureRESParameterHeaders(fhicl::ParameterSet const &, systtools::paramId_t,
+                             fhicl::ParameterSet &tool_options);
 systtools::SystMetaData
-ConfigureCOHParameterHeaders(fhiclsimple::ParameterSet const &, systtools::paramId_t,
-                             fhiclsimple::ParameterSet &tool_options);
+ConfigureCOHParameterHeaders(fhicl::ParameterSet const &, systtools::paramId_t,
+                             fhicl::ParameterSet &tool_options);
 
 systtools::SystMetaData
-ConfigureDISParameterHeaders(fhiclsimple::ParameterSet const &, systtools::paramId_t,
-                             fhiclsimple::ParameterSet &tool_options);
+ConfigureDISParameterHeaders(fhicl::ParameterSet const &, systtools::paramId_t,
+                             fhicl::ParameterSet &tool_options);
 
 systtools::SystMetaData
-ConfigureFSIParameterHeaders(fhiclsimple::ParameterSet const &, systtools::paramId_t,
-                             fhiclsimple::ParameterSet &tool_options);
+ConfigureFSIParameterHeaders(fhicl::ParameterSet const &, systtools::paramId_t,
+                             fhicl::ParameterSet &tool_options);
 
 systtools::SystMetaData
-ConfigureOtherParameterHeaders(fhiclsimple::ParameterSet const &,
+ConfigureOtherParameterHeaders(fhicl::ParameterSet const &,
                                systtools::paramId_t);
 
 } // namespace nusyst

--- a/src/nusystematics/systproviders/GENIEReWeight_tool.cc
+++ b/src/nusystematics/systproviders/GENIEReWeight_tool.cc
@@ -18,7 +18,7 @@
 #include <sstream>
 #include <fstream>
 
-using namespace fhiclsimple;
+using namespace fhicl;
 using namespace systtools;
 using namespace nusyst;
 
@@ -34,7 +34,7 @@ std::string GENIEReWeight::AsString() {
 SystMetaData GENIEReWeight::BuildSystMetaData(ParameterSet const &params,
                                               paramId_t firstParamId) {
 
-  tool_options = fhiclsimple::ParameterSet();
+  tool_options = fhicl::ParameterSet();
 
   bool ignore_parameter_dependence =
       params.get<bool>("ignore_parameter_dependence", false);
@@ -109,7 +109,7 @@ void GENIEReWeight::extend_ResponseToGENIEParameters(
 }
 
 bool GENIEReWeight::SetupResponseCalculator(
-    fhiclsimple::ParameterSet const &tool_options) {
+    fhicl::ParameterSet const &tool_options) {
 
   std::cout << "[INFO]: Setting up GENIE ReWeight instances..." << std::endl;
 

--- a/src/nusystematics/systproviders/GENIEReWeight_tool.hh
+++ b/src/nusystematics/systproviders/GENIEReWeight_tool.hh
@@ -19,13 +19,13 @@ class GENIEReWeight : public nusyst::IGENIESystProvider_tool {
 public:
   NEW_SYSTTOOLS_EXCEPT(invalid_engine_state);
 
-  explicit GENIEReWeight(fhiclsimple::ParameterSet const &);
+  explicit GENIEReWeight(fhicl::ParameterSet const &);
 
-  systtools::SystMetaData BuildSystMetaData(fhiclsimple::ParameterSet const &,
+  systtools::SystMetaData BuildSystMetaData(fhicl::ParameterSet const &,
                                             systtools::paramId_t);
-  fhiclsimple::ParameterSet GetExtraToolOptions() { return tool_options; }
+  fhicl::ParameterSet GetExtraToolOptions() { return tool_options; }
 
-  bool SetupResponseCalculator(fhiclsimple::ParameterSet const &);
+  bool SetupResponseCalculator(fhicl::ParameterSet const &);
 
   systtools::event_unit_response_t GetEventResponse(genie::EventRecord const &);
 
@@ -52,7 +52,7 @@ private:
   void extend_ResponseToGENIEParameters(
       std::vector<nusyst::GENIEResponseParameter> &&);
 
-  fhiclsimple::ParameterSet tool_options;
+  fhicl::ParameterSet tool_options;
 
   void InitValidTree();
 

--- a/src/nusystematics/systproviders/MINERvAE2p2h_tool.cc
+++ b/src/nusystematics/systproviders/MINERvAE2p2h_tool.cc
@@ -12,7 +12,7 @@ using namespace systtools;
 
 // #define MINERVAE2p2h_DEBUG
 
-MINERvAE2p2h::MINERvAE2p2h(fhiclsimple::ParameterSet const &params)
+MINERvAE2p2h::MINERvAE2p2h(fhicl::ParameterSet const &params)
     : IGENIESystProvider_tool(params),
       pidx_E2p2hResponse_nu(kParamUnhandled<size_t>),
       pidx_E2p2hResponse_nubar(kParamUnhandled<size_t>),
@@ -22,7 +22,7 @@ MINERvAE2p2h::MINERvAE2p2h(fhiclsimple::ParameterSet const &params)
       pidx_E2p2hB_nubar(kParamUnhandled<size_t>), valid_file(nullptr),
       valid_tree(nullptr) {}
 
-SystMetaData MINERvAE2p2h::BuildSystMetaData(fhiclsimple::ParameterSet const &ps,
+SystMetaData MINERvAE2p2h::BuildSystMetaData(fhicl::ParameterSet const &ps,
                                              paramId_t firstId) {
 
   SystMetaData smd;
@@ -41,7 +41,7 @@ SystMetaData MINERvAE2p2h::BuildSystMetaData(fhiclsimple::ParameterSet const &ps
     for (std::string const &p : {"E2p2h_A", "E2p2h_B"}) {
       std::string pname = p + "_" + nu;
       SystParamHeader phdr;
-      if (ParseFHiCLSimpleToolConfigurationParameter(ps, pname, phdr,
+      if (ParseFhiclToolConfigurationParameter(ps, pname, phdr,
                                                      firstId)) {
         phdr.systParamId = firstId++;
         if (!ignore_parameter_dependence) {
@@ -85,7 +85,7 @@ SystMetaData MINERvAE2p2h::BuildSystMetaData(fhiclsimple::ParameterSet const &ps
 }
 
 bool MINERvAE2p2h::SetupResponseCalculator(
-    fhiclsimple::ParameterSet const &tool_options) {
+    fhicl::ParameterSet const &tool_options) {
 
   SystMetaData const &md = GetSystMetaData();
 

--- a/src/nusystematics/systproviders/MINERvAE2p2h_tool.hh
+++ b/src/nusystematics/systproviders/MINERvAE2p2h_tool.hh
@@ -17,12 +17,12 @@
 class MINERvAE2p2h : public nusyst::IGENIESystProvider_tool {
 
 public:
-  explicit MINERvAE2p2h(fhiclsimple::ParameterSet const &);
+  explicit MINERvAE2p2h(fhicl::ParameterSet const &);
 
-  bool SetupResponseCalculator(fhiclsimple::ParameterSet const &);
-  fhiclsimple::ParameterSet GetExtraToolOptions() { return tool_options; }
+  bool SetupResponseCalculator(fhicl::ParameterSet const &);
+  fhicl::ParameterSet GetExtraToolOptions() { return tool_options; }
 
-  systtools::SystMetaData BuildSystMetaData(fhiclsimple::ParameterSet const &,
+  systtools::SystMetaData BuildSystMetaData(fhicl::ParameterSet const &,
                                             systtools::paramId_t);
 
   systtools::event_unit_response_t GetEventResponse(genie::EventRecord const &);
@@ -32,7 +32,7 @@ public:
   ~MINERvAE2p2h();
 
 private:
-  fhiclsimple::ParameterSet tool_options;
+  fhicl::ParameterSet tool_options;
   std::pair<double, double> LimitWeights;
 
   bool ignore_parameter_dependence;

--- a/src/nusystematics/systproviders/MINERvAq0q3Weighting_tool.cc
+++ b/src/nusystematics/systproviders/MINERvAq0q3Weighting_tool.cc
@@ -12,7 +12,7 @@
 
 using namespace systtools;
 using namespace nusyst;
-using namespace fhiclsimple;
+using namespace fhicl;
 
 MINERvAq0q3Weighting::MINERvAq0q3Weighting(ParameterSet const &params)
     : IGENIESystProvider_tool(params), RPATemplateReweighter(nullptr),
@@ -42,8 +42,8 @@ SystMetaData MINERvAq0q3Weighting::BuildSystMetaData(ParameterSet const &cfg,
              "for the layout.";
     }
 
-    fhiclsimple::ParameterSet ps =
-        cfg.get<fhiclsimple::ParameterSet>("MINERvATune_RPA_input_manifest");
+    fhicl::ParameterSet ps =
+        cfg.get<fhicl::ParameterSet>("MINERvATune_RPA_input_manifest");
     tool_options.put("MINERvATune_RPA_input_manifest", ps);
 
     smd.push_back(param);
@@ -59,22 +59,22 @@ SystMetaData MINERvAq0q3Weighting::BuildSystMetaData(ParameterSet const &cfg,
 
     if (parameter_per_2p2h_universe) {
       systtools::SystParamHeader param_CV, param_NN, param_np, param_QE;
-      if (ParseFHiCLSimpleToolConfigurationParameter(
+      if (ParseFhiclToolConfigurationParameter(
               cfg, "Mnv2p2hGaussEnhancement_CV", param_CV, firstId)) {
         param_CV.systParamId = firstId++;
         smd.push_back(param_CV);
       }
-      if (ParseFHiCLSimpleToolConfigurationParameter(
+      if (ParseFhiclToolConfigurationParameter(
               cfg, "Mnv2p2hGaussEnhancement_NN", param_NN, firstId)) {
         param_NN.systParamId = firstId++;
         smd.push_back(param_NN);
       }
-      if (ParseFHiCLSimpleToolConfigurationParameter(
+      if (ParseFhiclToolConfigurationParameter(
               cfg, "Mnv2p2hGaussEnhancement_np", param_np, firstId)) {
         param_np.systParamId = firstId++;
         smd.push_back(param_np);
       }
-      if (ParseFHiCLSimpleToolConfigurationParameter(
+      if (ParseFhiclToolConfigurationParameter(
               cfg, "Mnv2p2hGaussEnhancement_QE", param_QE, firstId)) {
         param_QE.systParamId = firstId++;
         smd.push_back(param_QE);
@@ -82,7 +82,7 @@ SystMetaData MINERvAq0q3Weighting::BuildSystMetaData(ParameterSet const &cfg,
 
     } else {
       systtools::SystParamHeader param;
-      if (ParseFHiCLSimpleToolConfigurationParameter(
+      if (ParseFhiclToolConfigurationParameter(
               cfg, "Mnv2p2hGaussEnhancement", param, firstId)) {
         param.systParamId = firstId++;
       } else {
@@ -109,7 +109,7 @@ SystMetaData MINERvAq0q3Weighting::BuildSystMetaData(ParameterSet const &cfg,
 }
 
 bool MINERvAq0q3Weighting::SetupResponseCalculator(
-    fhiclsimple::ParameterSet const &tool_options) {
+    fhicl::ParameterSet const &tool_options) {
 
   if (HasParam(GetSystMetaData(), "MINERvATune_RPA")) {
     ConfiguredParameters[param_t::kMINERvARPA] =
@@ -126,7 +126,7 @@ bool MINERvAq0q3Weighting::SetupResponseCalculator(
     }
 
     RPATemplateReweighter = std::make_unique<MINERvARPAq0q3_ReWeight>(
-        tool_options.get<fhiclsimple::ParameterSet>(
+        tool_options.get<fhicl::ParameterSet>(
             "MINERvATune_RPA_input_manifest"));
   }
 

--- a/src/nusystematics/systproviders/MINERvAq0q3Weighting_tool.hh
+++ b/src/nusystematics/systproviders/MINERvAq0q3Weighting_tool.hh
@@ -47,13 +47,13 @@ class MINERvAq0q3Weighting : public nusyst::IGENIESystProvider_tool {
   std::map<param_t, size_t> ConfiguredParameters;
 
 public:
-  explicit MINERvAq0q3Weighting(fhiclsimple::ParameterSet const &);
+  explicit MINERvAq0q3Weighting(fhicl::ParameterSet const &);
 
-  bool SetupResponseCalculator(fhiclsimple::ParameterSet const &);
+  bool SetupResponseCalculator(fhicl::ParameterSet const &);
 
-  fhiclsimple::ParameterSet GetExtraToolOptions() { return tool_options; }
+  fhicl::ParameterSet GetExtraToolOptions() { return tool_options; }
 
-  systtools::SystMetaData BuildSystMetaData(fhiclsimple::ParameterSet const &,
+  systtools::SystMetaData BuildSystMetaData(fhicl::ParameterSet const &,
                                             systtools::paramId_t);
 
   double GetMINERvARPATuneWeight(double val, double q0, double q3);
@@ -67,7 +67,7 @@ public:
   ~MINERvAq0q3Weighting();
 
 private:
-  fhiclsimple::ParameterSet tool_options;
+  fhicl::ParameterSet tool_options;
   std::pair<double, double> MEC_LimitWeights;
 
   void InitValidTree();

--- a/src/nusystematics/systproviders/MKSinglePiTemplate_tool.cc
+++ b/src/nusystematics/systproviders/MKSinglePiTemplate_tool.cc
@@ -11,7 +11,7 @@
 
 using namespace systtools;
 using namespace nusyst;
-using namespace fhiclsimple;
+using namespace fhicl;
 
 // #define DEBUG_MKSINGLEPI
 
@@ -33,7 +33,7 @@ SystMetaData MKSinglePiTemplate::BuildSystMetaData(ParameterSet const &cfg,
   SystMetaData smd;
 
   systtools::SystParamHeader phdr;
-  if (ParseFHiCLSimpleToolConfigurationParameter(cfg, "MKSPP_ReWeight", phdr,
+  if (ParseFhiclToolConfigurationParameter(cfg, "MKSPP_ReWeight", phdr,
                                                  firstId)) {
     phdr.systParamId = firstId++;
     smd.push_back(phdr);
@@ -50,8 +50,8 @@ SystMetaData MKSinglePiTemplate::BuildSystMetaData(ParameterSet const &cfg,
            "TemplateResponseCalculatorBase.hh "
            "for the layout.";
   }
-  fhiclsimple::ParameterSet templateManifest =
-      cfg.get<fhiclsimple::ParameterSet>("MKSPP_Template_input_manifest");
+  fhicl::ParameterSet templateManifest =
+      cfg.get<fhicl::ParameterSet>("MKSPP_Template_input_manifest");
   tool_options.put("MKSPP_Template_input_manifest", templateManifest);
 
   size_t NNuChannels = 0;
@@ -105,7 +105,7 @@ SystMetaData MKSinglePiTemplate::BuildSystMetaData(ParameterSet const &cfg,
 }
 
 bool MKSinglePiTemplate::SetupResponseCalculator(
-    fhiclsimple::ParameterSet const &tool_options) {
+    fhicl::ParameterSet const &tool_options) {
 
   genie::Messenger::Instance()->SetPrioritiesFromXmlFile(
       "Messenger_whisper.xml");
@@ -126,8 +126,8 @@ bool MKSinglePiTemplate::SetupResponseCalculator(
            "please report to the maintiner.";
   }
 
-  fhiclsimple::ParameterSet const &templateManifest =
-      tool_options.get<fhiclsimple::ParameterSet>("MKSPP_Template_input_manifest");
+  fhicl::ParameterSet const &templateManifest =
+      tool_options.get<fhicl::ParameterSet>("MKSPP_Template_input_manifest");
 
   ResponseParameterIdx = GetParamIndex(GetSystMetaData(), "MKSPP_ReWeight");
 
@@ -146,7 +146,7 @@ bool MKSinglePiTemplate::SetupResponseCalculator(
 
     TemplateHelper th;
     th.Template = std::make_unique<MKSinglePiTemplate_ReWeight>(
-        templateManifest.get<fhiclsimple::ParameterSet>(ch.name));
+        templateManifest.get<fhicl::ParameterSet>(ch.name));
     th.ZeroIsValid = th.Template->IsValidVariation(0);
 
     ChannelParameterMapping.emplace(ch.channel, std::move(th));

--- a/src/nusystematics/systproviders/MKSinglePiTemplate_tool.hh
+++ b/src/nusystematics/systproviders/MKSinglePiTemplate_tool.hh
@@ -25,12 +25,12 @@ class MKSinglePiTemplate : public nusyst::IGENIESystProvider_tool {
   std::map<genie::SppChannel_t, TemplateHelper> ChannelParameterMapping;
 
 public:
-  explicit MKSinglePiTemplate(fhiclsimple::ParameterSet const &);
+  explicit MKSinglePiTemplate(fhicl::ParameterSet const &);
 
-  bool SetupResponseCalculator(fhiclsimple::ParameterSet const &);
-  fhiclsimple::ParameterSet GetExtraToolOptions() { return tool_options; }
+  bool SetupResponseCalculator(fhicl::ParameterSet const &);
+  fhicl::ParameterSet GetExtraToolOptions() { return tool_options; }
 
-  systtools::SystMetaData BuildSystMetaData(fhiclsimple::ParameterSet const &,
+  systtools::SystMetaData BuildSystMetaData(fhicl::ParameterSet const &,
                                             systtools::paramId_t);
 
   systtools::event_unit_response_t GetEventResponse(genie::EventRecord const &);
@@ -44,7 +44,7 @@ private:
   bool use_Q2W_templates;
   bool Q2_or_q0_is_x;
 
-  fhiclsimple::ParameterSet tool_options;
+  fhicl::ParameterSet tool_options;
 
   void InitValidTree();
 

--- a/src/nusystematics/systproviders/MiscInteractionSysts_tool.cc
+++ b/src/nusystematics/systproviders/MiscInteractionSysts_tool.cc
@@ -11,7 +11,7 @@
 
 using namespace nusyst;
 
-MiscInteractionSysts::MiscInteractionSysts(fhiclsimple::ParameterSet const &params)
+MiscInteractionSysts::MiscInteractionSysts(fhicl::ParameterSet const &params)
     : IGENIESystProvider_tool(params),
       pidx_C12ToAr40_2p2hScaling_nu(systtools::kParamUnhandled<size_t>),
       pidx_C12ToAr40_2p2hScaling_nubar(systtools::kParamUnhandled<size_t>),
@@ -21,7 +21,7 @@ MiscInteractionSysts::MiscInteractionSysts(fhiclsimple::ParameterSet const &para
       valid_file(nullptr), valid_tree(nullptr) {}
 
 systtools::SystMetaData
-MiscInteractionSysts::BuildSystMetaData(fhiclsimple::ParameterSet const &ps,
+MiscInteractionSysts::BuildSystMetaData(fhicl::ParameterSet const &ps,
                                         systtools::paramId_t firstId) {
 
   systtools::SystMetaData smd;
@@ -30,7 +30,7 @@ MiscInteractionSysts::BuildSystMetaData(fhiclsimple::ParameterSet const &ps,
        {"C12ToAr40_2p2hScaling_nu", "C12ToAr40_2p2hScaling_nubar",
         "nuenuebar_xsec_ratio", "nuenumu_xsec_ratio", "SPPLowQ2Suppression"}) {
     systtools::SystParamHeader phdr;
-    if (ParseFHiCLSimpleToolConfigurationParameter(ps, pname, phdr, firstId)) {
+    if (ParseFhiclToolConfigurationParameter(ps, pname, phdr, firstId)) {
       phdr.systParamId = firstId++;
       smd.push_back(phdr);
     }
@@ -43,7 +43,7 @@ MiscInteractionSysts::BuildSystMetaData(fhiclsimple::ParameterSet const &ps,
 }
 
 bool MiscInteractionSysts::SetupResponseCalculator(
-    fhiclsimple::ParameterSet const &tool_options) {
+    fhicl::ParameterSet const &tool_options) {
 
   systtools::SystMetaData const &md = GetSystMetaData();
 

--- a/src/nusystematics/systproviders/MiscInteractionSysts_tool.hh
+++ b/src/nusystematics/systproviders/MiscInteractionSysts_tool.hh
@@ -11,12 +11,12 @@
 class MiscInteractionSysts : public nusyst::IGENIESystProvider_tool {
 
 public:
-  explicit MiscInteractionSysts(fhiclsimple::ParameterSet const &);
+  explicit MiscInteractionSysts(fhicl::ParameterSet const &);
 
-  bool SetupResponseCalculator(fhiclsimple::ParameterSet const &);
-  fhiclsimple::ParameterSet GetExtraToolOptions() { return tool_options; }
+  bool SetupResponseCalculator(fhicl::ParameterSet const &);
+  fhicl::ParameterSet GetExtraToolOptions() { return tool_options; }
 
-  systtools::SystMetaData BuildSystMetaData(fhiclsimple::ParameterSet const &,
+  systtools::SystMetaData BuildSystMetaData(fhicl::ParameterSet const &,
                                             systtools::paramId_t);
 
   systtools::event_unit_response_t GetEventResponse(genie::EventRecord const &);
@@ -26,7 +26,7 @@ public:
   ~MiscInteractionSysts();
 
 private:
-  fhiclsimple::ParameterSet tool_options;
+  fhicl::ParameterSet tool_options;
 
   size_t pidx_C12ToAr40_2p2hScaling_nu;
   size_t pidx_C12ToAr40_2p2hScaling_nubar;

--- a/src/nusystematics/systproviders/NOvAStyleNonResPionNorm_tool.cc
+++ b/src/nusystematics/systproviders/NOvAStyleNonResPionNorm_tool.cc
@@ -5,12 +5,12 @@
 using namespace nusyst;
 
 NOvAStyleNonResPionNorm::NOvAStyleNonResPionNorm(
-    fhiclsimple::ParameterSet const &params)
+    fhicl::ParameterSet const &params)
     : IGENIESystProvider_tool(params), valid_file(nullptr),
       valid_tree(nullptr) {}
 
 systtools::SystMetaData
-NOvAStyleNonResPionNorm::BuildSystMetaData(fhiclsimple::ParameterSet const &ps,
+NOvAStyleNonResPionNorm::BuildSystMetaData(fhicl::ParameterSet const &ps,
                                            systtools::paramId_t firstId) {
 
   systtools::SystMetaData smd;
@@ -23,7 +23,7 @@ NOvAStyleNonResPionNorm::BuildSystMetaData(fhiclsimple::ParameterSet const &ps,
               BuildNRPiChannel(IsNeutrino, IsCC, TargetNucleon, NPi);
 
           systtools::SystParamHeader ch_param;
-          if (ParseFHiCLSimpleToolConfigurationParameter(
+          if (ParseFhiclToolConfigurationParameter(
                   ps, GetNRPiChannelName(chan), ch_param, firstId)) {
             ch_param.systParamId = firstId++;
             smd.push_back(ch_param);
@@ -51,7 +51,7 @@ NOvAStyleNonResPionNorm::BuildSystMetaData(fhiclsimple::ParameterSet const &ps,
 }
 
 bool NOvAStyleNonResPionNorm::SetupResponseCalculator(
-    fhiclsimple::ParameterSet const &tool_options) {
+    fhicl::ParameterSet const &tool_options) {
 
   systtools::SystMetaData const &md = GetSystMetaData();
 

--- a/src/nusystematics/systproviders/NOvAStyleNonResPionNorm_tool.hh
+++ b/src/nusystematics/systproviders/NOvAStyleNonResPionNorm_tool.hh
@@ -19,12 +19,12 @@ class NOvAStyleNonResPionNorm : public nusyst::IGENIESystProvider_tool {
   std::vector<channel_param> ChannelParameterMapping;
 
 public:
-  explicit NOvAStyleNonResPionNorm(fhiclsimple::ParameterSet const &);
+  explicit NOvAStyleNonResPionNorm(fhicl::ParameterSet const &);
 
-  bool SetupResponseCalculator(fhiclsimple::ParameterSet const &);
-  fhiclsimple::ParameterSet GetExtraToolOptions() { return tool_options; }
+  bool SetupResponseCalculator(fhicl::ParameterSet const &);
+  fhicl::ParameterSet GetExtraToolOptions() { return tool_options; }
 
-  systtools::SystMetaData BuildSystMetaData(fhiclsimple::ParameterSet const &,
+  systtools::SystMetaData BuildSystMetaData(fhicl::ParameterSet const &,
                                             systtools::paramId_t);
 
   systtools::event_unit_response_t GetEventResponse(genie::EventRecord const &);
@@ -34,7 +34,7 @@ public:
   ~NOvAStyleNonResPionNorm();
 
 private:
-  fhiclsimple::ParameterSet tool_options;
+  fhicl::ParameterSet tool_options;
 
   // Dial has uniform response of OneSigmaResponse between WBegin and
   // WTransition, where it linearly reduces to a response of HighWResponse at

--- a/src/nusystematics/utility/make_instance.hh
+++ b/src/nusystematics/utility/make_instance.hh
@@ -12,7 +12,7 @@
 #include "nusystematics/systproviders/MiscInteractionSysts_tool.hh"
 #include "nusystematics/systproviders/NOvAStyleNonResPionNorm_tool.hh"
 
-#include "fhiclcppsimple/ParameterSet.h"
+#include "fhiclcpp/ParameterSet.h"
 
 #include <memory>
 
@@ -21,7 +21,7 @@ namespace nusyst {
 NEW_SYSTTOOLS_EXCEPT(unknown_nusyst_systprovider);
 
 inline std::unique_ptr<IGENIESystProvider_tool>
-make_instance(fhiclsimple::ParameterSet const &paramset) {
+make_instance(fhicl::ParameterSet const &paramset) {
   std::string tool_type = paramset.get<std::string>("tool_type");
 
   if (tool_type == "GENIEReWeight") {

--- a/src/nusystematics/utility/response_helper.hh
+++ b/src/nusystematics/utility/response_helper.hh
@@ -9,7 +9,7 @@
 
 #include "systematicstools/utility/ParameterAndProviderConfigurationUtility.hh"
 
-#include "fhiclcppsimple/make_ParameterSet.h"
+#include "fhiclcpp/make_ParameterSet.h"
 
 #include "Framework/EventGen/EventRecord.h"
 
@@ -48,7 +48,7 @@ public:
     return syst_providers;
   };
 
-  void LoadProvidersAndHeaders(fhiclsimple::ParameterSet const &ps) {
+  void LoadProvidersAndHeaders(fhicl::ParameterSet const &ps) {
     syst_providers = systtools::ConfigureISystProvidersFromParameterHeaders<
         IGENIESystProvider_tool>(ps, make_instance);
     
@@ -72,9 +72,9 @@ public:
   void LoadConfiguration(std::string const &fhicl_config_filename) {
     config_file = fhicl_config_filename;
 
-    fhiclsimple::ParameterSet ps = fhiclsimple::make_ParameterSet(config_file);
+    fhicl::ParameterSet ps = fhicl::make_ParameterSet(config_file);
 
-    LoadProvidersAndHeaders(ps.get<fhiclsimple::ParameterSet>(
+    LoadProvidersAndHeaders(ps.get<fhicl::ParameterSet>(
         "generated_systematic_provider_configuration"));
 
     ProfilerRate = ps.get<size_t>("ProfileRate", 0);


### PR DESCRIPTION
This PR makes it possible to use `fhiclcpp` without using `cetmodules`. Because nusystematics is already built in a UPS environment, the only thing that is necessary is to invoke:

`setup fhiclcpp v4_17_00 -q e20:prof`

before invoking `cmake ../nusystematics-src/`.